### PR TITLE
Updated getFilePreview method in config.js

### DIFF
--- a/src/appwite/config.js
+++ b/src/appwite/config.js
@@ -125,7 +125,7 @@ class Service{
 
     getFilePreview(fileID){
         try {
-            return this.bucket.getFilePreview(
+            return this.bucket.getFileView(
             config.appWriteBucketID,
             fileID
         )


### PR DESCRIPTION
you are not getting the images on the site , becasue getFilePreview method is now belong to their Pro plan , so I fixed the method with new method called getFileView.